### PR TITLE
Address mismatch in lengths of subproblem / subdim output

### DIFF
--- a/R/fullmatch.R
+++ b/R/fullmatch.R
@@ -385,7 +385,7 @@ fullmatch.matrix <- function(x,
   }
 
   if (any(!is.na(mean.controls))) {
-    if (any(mean.controls > lapply(subdim(x), function(x) x[2]/x[1]), na.rm=TRUE)) {
+    if (any(mean.controls > lapply(problems, function(p) {x <- subdim(p)[[1]] ;  x[2]/x[1]}), na.rm=TRUE)) {
       stop("mean.controls cannot be larger than the ratio of number of controls to treatments")
     }
   }
@@ -402,7 +402,7 @@ fullmatch.matrix <- function(x,
 
   if (any(!is.na(mean.controls) & is.na(omit.fraction))) {
     user.input.mean.controls <- TRUE
-    omit.fraction <- 1 - mapply(function(x,y) x*y[1]/y[2], mean.controls, subdim(x))
+    omit.fraction <- 1 - mapply(function(x,y) {z <- subdim(y)[[1]] ; x*z[1]/z[2]}, mean.controls, problems)
   }
 
   total.n <- sum(dim(x))


### PR DESCRIPTION
This commit addresses some warnings and length mismatch issues.  I didn't have a 
working build environment handy so I wasn't able to check that it didn't break other things.
Perhaps after that's been done and it's had a spot check, it's ready to be merged in. 

It's possible that the edge case that this addresses is only arising in my example because 
of another, low-lying and potential more important, problem. See my recent comment 
to [master  403b9278]. that shouldn't have to be figured out to decide about this merge, but 
maybe it's a good time to decide whether it's sensible code that I just missed the point of or whether it should be its own issue.

Cf #129. Unfortunately I wasn't able to confirm that this didn't
break stuff before committing it.
Done to quiet warnings as follows.  Unfortunately the example
this comes from isn't useful as a test case.

Warning in mean.controls > lapply(subdim(x), function(x) x[2]/x[1]) :
  longer object length is not a multiple of shorter object length
Warning in mapply(function(x, y) x * y[1]/y[2], mean.controls, subdim(x)) :
  longer argument not a multiple of length of shorter
Warning in mapply(.fullmatch.with.recovery, problems, min.controls, max.controls,  :
  longer argument not a multiple of length of shorter
Warning in mapply(.fullmatch.with.recovery, problems, min.controls, max.controls,  :
  longer argument not a multiple of length of shorter
Warning in mapply(.fullmatch.with.recovery, problems, min.controls, max.controls,  :
  longer argument not a multiple of length of shorter