### PR TITLE
Add a paragraph about missing data on covariates

### DIFF
--- a/R/match_on.R
+++ b/R/match_on.R
@@ -38,21 +38,12 @@
 #' \code{Inf} in \code{within} will be \code{Inf} in the distance matrix
 #' returned by \code{match_on}. This argument can reduce the processing time
 #' needed to compute sparse distance matrices.
-#'
-#' When covariates provided to \code{match_on} contain missing values, by default 
-#' \code{match_on} will (1) create a matrix of distances between observations which 
-#' have only valid values for **all** covariates and then (2) append a matrix of Inf values 
-#' for distances between observations that have **any** missing values on any of the covariates. 
-#' This means that no matches will be possible between observations that have any missing 
-#' values and any other observation in the dataset. It also means that the distance matrices returned
-#' by \code{match_on} will have Number of Treated rows and Number of Control columns regardless of the
-#' amoung of missing data in the covariates.
 #' 
 #' Details for each particular first type of argument follow:
 #'
-#' @param x An object defining how to create the distances. All methods require
-#'   some form of names (e.g. \code{names} for vectors or \code{rownames} for
-#'   matrix like objects)
+#' @param x A model formula, fitted glm or other object implicitly specifying a distance; see blurbs on specific methods in Details. (All methods require
+#'   some form of names: e.g. \code{names} for vectors or \code{rownames} for
+#'   matrix like objects.)
 #' @param within A valid distance specification, such as the result of
 #'   \code{\link{exactMatch}} or \code{\link{caliper}}. Finite entries indicate
 #'   which distances to create. Including this argument can significantly speed
@@ -127,6 +118,13 @@ match_on <- function(x, within = NULL, caliper = NULL, exclude = NULL, data=NULL
 #'   \code{within=exactMatch(y ~ strata(s))}. Note that when combining with
 #'   the \code{caliper} argument, the standard deviation used for the caliper will be
 #'   computed across all strata, not within each strata.
+#'
+#'   If data used to fit the glm have missing values in the left-hand side
+#'   (dependent) variable, these observations are omitted from the output of
+#'   match_on.  If there are observations with missing values in right hand
+#'   side (independent) variables, then a re-fit of the model after imputing
+#'   these variables using a simple scheme and adding indicator variables of
+#'   missingness will be attempted, via the \code{\link{scores}} function. 
 #'
 #' @param standardization.scale Function for rescaling of \code{scores(x)}, or
 #'   \code{NULL}; defaults to \code{mad}.  (See Details.)
@@ -247,8 +245,8 @@ are there missing values in data?")
 #'   (1 representing treated units and 0 control units) or logical
 #'   (\code{TRUE} for treated, \code{FALSE} for controls). (Earlier versions of
 #'   the software accepted factor variables and other types of numeric variable; you
-#'   may have to update existing scripts to get them to run.) A unit with NA
-#'   treatment status is ignored and will not be included in the distance output.
+#'   may have to update existing scripts to get them to run.)
+#'
 #'
 #'   As an alternative to specifying a \code{within} argument, when \code{x} is
 #'   a formula, the \code{strata} command can be used inside the formula to specify
@@ -257,8 +255,16 @@ are there missing values in data?")
 #'   not use both methods (\code{within} and \code{strata} simultaneously. Note
 #'   that when combining with the \code{caliper} argument, the standard
 #'   deviation used for the caliper will be computed across all strata, not
-#'   within each strata.
+#'   separately by stratum.
 #'
+#'   A unit with NA treatment status (\code{Z}) is ignored and will not be included in the distance output.
+#'  Missing values in variables on the right hand side of the formula are handled as follows. By default 
+#' \code{match_on} will (1) create a matrix of distances between observations which 
+#' have only valid values for **all** covariates and then (2) append matrices of Inf values 
+#' for distances between observations either of which has a missing values on any of the right-hand-side variables. 
+#' (I.e., observations with missing values are retained in the output, but
+#' matches involving them are forbidden.)
+#' 
 #' @param subset A subset of the data to use in creating the distance
 #'   specification.
 #' @param method A string indicating which method to use in computing the

--- a/R/match_on.R
+++ b/R/match_on.R
@@ -41,9 +41,7 @@
 #' 
 #' Details for each particular first type of argument follow:
 #'
-#' @param x A model formula, fitted glm or other object implicitly specifying a distance; see blurbs on specific methods in Details. (All methods require
-#'   some form of names: e.g. \code{names} for vectors or \code{rownames} for
-#'   matrix like objects.)
+#' @param x A model formula, fitted glm or other object implicitly specifying a distance; see blurbs on specific methods in Details. 
 #' @param within A valid distance specification, such as the result of
 #'   \code{\link{exactMatch}} or \code{\link{caliper}}. Finite entries indicate
 #'   which distances to create. Including this argument can significantly speed

--- a/R/match_on.R
+++ b/R/match_on.R
@@ -39,6 +39,15 @@
 #' returned by \code{match_on}. This argument can reduce the processing time
 #' needed to compute sparse distance matrices.
 #'
+#' When covariates provided to \code{match_on} contain missing values, by default 
+#' \code{match_on} will (1) create a matrix of distances between observations which 
+#' have only valid values for **all** covariates and then (2) append a matrix of Inf values 
+#' for distances between observations that have **any** missing values on any of the covariates. 
+#' This means that no matches will be possible between observations that have any missing 
+#' values and any other observation in the dataset. It also means that the distance matrices returned
+#' by \code{match_on} will have Number of Treated rows and Number of Control columns regardless of the
+#' amoung of missing data in the covariates.
+#' 
 #' Details for each particular first type of argument follow:
 #'
 #' @param x An object defining how to create the distances. All methods require


### PR DESCRIPTION
I discovered how match_on was handling missing data on covariates by some sleuthing and figured that users might want to know this especially if, by chance, they give a formula to match_on where some of the covariates have missing data for some observations and then those observations are kicked out of subsequant matches.