### PR TITLE
consistent whitespacing

### DIFF
--- a/src/map.cc
+++ b/src/map.cc
@@ -237,7 +237,7 @@ int hsearch_r(ENTRY item, ACTION action, ENTRY **retval, struct hsearch_data *ht
              available indeces.  */
           if (idx <= hval2)
 	    idx = htab->size + idx - hval2;
-	  else
+          else
 	    idx -= hval2;
 
 	  /* If we visited all entries leave the loop unsuccessfully.  */


### PR DESCRIPTION
This line was flagged by some tooling as having "inconsistent indentation" (despite its appearance), I think it's because there's a mix of `\t` and ` `.