### PR TITLE
Small fix to DESCRIPTION to head off incomplete final line error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -94,4 +94,5 @@ Collate:
 VignetteBuilder: knitr
 RoxygenNote: 7.2.3
 Encoding: UTF-8
-Remotes: josherrickson/rrelaxiv
+Remotes:
+    josherrickson/rrelaxiv


### PR DESCRIPTION
Fix Remotes: so that we don't get an "incomplete final line" error in R 4.3.2