### PR TITLE
subset.BISM() adjustment

### DIFF
--- a/R/InfinitySparseMatrix.R
+++ b/R/InfinitySparseMatrix.R
@@ -1117,14 +1117,15 @@ as.list.DenseMatrix <- function(x, ...) {
 ##' @rdname bism.subset
 ##' @export
 subset.BlockedInfinitySparseMatrix <- function(x, subset, select, ...) {
-    newBism <- callNextMethod(x, subet, select)
+    newBism <- callNextMethod(x, subset, select)
     subGroups <- NULL
-    if (!is.null(x@groups)) {
+    if (!is.null(names(x@groups))) {
         subNames <- names(x@groups)
         subNames <- subNames[which(subNames %in% newBism@rownames ||
                                    subNames %in% newBism@colnames)]
         subGroups <- x@groups[subNames]
     }
-    newBism@groups <- subGroups
-    return(newBism)
+  new("BlockedInfinitySparseMatrix",
+      newBism,
+      groups = subGroups)
 }


### PR DESCRIPTION
This subset.BISM method has the right idea, but I spotted a few issues that I thought I'd point out via PR:

1. `subset` was misspelled in one place
2. Every BISM should have an `@groups`, the thing determining whether we can subset it as a BISM is whether its `@groups` has names 
3. To get it to return a BISM, return value has to be explicitly typed as such.

This "corrected" method has not yet been tested and may well have issues of its own. 