### PR TITLE
prefer treatment over treated

### DIFF
--- a/R/InfinitySparseMatrix.R
+++ b/R/InfinitySparseMatrix.R
@@ -79,7 +79,7 @@ dim.InfinitySparseMatrix <- function(x) {
 #' @export
 as.matrix.InfinitySparseMatrix <- function(x, ...) {
   dims <- dim(x) ; nrow <- dims[1] ; ncol <- dims[2]
-  v <- matrix(Inf, nrow = nrow, ncol = ncol, dimnames = list(treated = x@rownames, control = x@colnames))
+  v <- matrix(Inf, nrow = nrow, ncol = ncol, dimnames = list(treatment = x@rownames, control = x@colnames))
 
   # There might be a better, vectorized way to do this, but this is correct, if slow
   n <- length(x)
@@ -137,7 +137,7 @@ setMethod("dimnames", "InfinitySparseMatrix", function(x) {
   if (is.null(x@rownames) & is.null(x@colnames)) {
     return(NULL)
   }
-  list(treated = x@rownames, control = x@colnames)
+  list(treatment = x@rownames, control = x@colnames)
 })
 
 #' @rdname dimnames-InfinitySparseMatrix
@@ -178,8 +178,8 @@ ismOpHandler <- function(binOp, e1, e2) {
     warning("One matrix has dimnames and the other does not. Proper ordering is not guaranteed.")
   }
   else if (!is.null(dimnames(e1)) | !is.null(dimnames(e2))) {
-    t1 <- dimnames(e1)$treated
-    t2 <- dimnames(e2)$treated
+    t1 <- dimnames(e1)$treatment
+    t2 <- dimnames(e2)$treatment
     c1 <- dimnames(e1)$control
     c2 <- dimnames(e2)$control
     t1extra <- setdiff(t1, t2)

--- a/R/zzzDistanceSpecification.R
+++ b/R/zzzDistanceSpecification.R
@@ -32,7 +32,7 @@ function(distances) {
 
   # call factor() in order to drop unused levels
   tmp <- data.frame(control = factor(controls[idx]),
-                    treated = factor(treatments[idx]),
+                    treatment = factor(treatments[idx]),
                     distance = raw.distances[idx])
 
   return(tmp)
@@ -44,7 +44,7 @@ setMethod("prepareMatching", "InfinitySparseMatrix", function(distances) {
   }
 
   tmp <- data.frame(control = as.factor(distances@colnames[distances@cols]),
-                    treated = as.factor(distances@rownames[distances@rows]),
+                    treatment = as.factor(distances@rownames[distances@rows]),
                     distance = distances@.Data)
 
   return(tmp)
@@ -162,7 +162,7 @@ validDistanceSpecification <- function(distance, stopOnProblem = TRUE) {
 
   if (is.null(dimnames(distance))) {
     if (stopOnProblem) {
-      stop("Invalid distance: object must have dimnames. Rows are treated, columns are control.")
+      stop("Invalid distance: object must have dimnames. Rows are treatment, columns are control.")
     }
     return(FALSE)
   }

--- a/tests/testthat/test.DistanceSpecification.R
+++ b/tests/testthat/test.DistanceSpecification.R
@@ -18,7 +18,7 @@ test_that("Matrix => nodes and arcs", {
 
   m.result <- prepareMatching(m)
   expect_equal(dim(m.result), c(4, 3))
-  expect_equal(unique(m.result$treated), as.factor(c("D", "E")))
+  expect_equal(unique(m.result$treatment), as.factor(c("D", "E")))
   expect_equal(unique(m.result$control), as.factor(c("A", "B", "C")))
 
   # NA's and NaN's the same as Inf's
@@ -40,7 +40,7 @@ test_that("ISM => nodes and arcs", {
   res.ISM <- prepareMatching(A)
 
   expect_equal(dim(res.ISM), c(4, 3))
-  expect_equal(unique(res.ISM$treated), as.factor(c("D", "E")))
+  expect_equal(unique(res.ISM$treatment), as.factor(c("D", "E")))
   expect_equal(unique(res.ISM$control), as.factor(c("A", "B", "C")))
 
   # NA's and NaN's the same as Inf's
@@ -66,10 +66,10 @@ test_that("Subproblems", {
                          logical(1))))
 
   m1 <- matrix(0, nrow = 2, ncol = 3,
-    dimnames = list(treated = c("b", "d"), control = c("a", "c", "e")))
+    dimnames = list(treatment = c("b", "d"), control = c("a", "c", "e")))
 
   m2 <- matrix(0, nrow = 3, ncol = 2,
-    dimnames = list(treated = c("f", "h", "j"), control = c("g", "i")))
+    dimnames = list(treatment = c("f", "h", "j"), control = c("g", "i")))
 
   expect_equal(as.matrix(res.em[[1]]), m1)
   expect_equal(as.matrix(res.em[[2]]), m2)

--- a/tests/testthat/test.InfinitySparseMatrix.R
+++ b/tests/testthat/test.InfinitySparseMatrix.R
@@ -44,7 +44,7 @@ test_that("ISM Basics", {
 
 test_that("ISM Handles Names", {
   m <- matrix(c(1,Inf, 2, 3), nrow = 2, ncol = 2,
-              dimnames = list(treated = c("A", "B"),
+              dimnames = list(treatment = c("A", "B"),
                               control = c("C", "D")))
 
   expect_equal(as.matrix(as(m, "InfinitySparseMatrix")), m)
@@ -52,7 +52,7 @@ test_that("ISM Handles Names", {
   A <- makeInfinitySparseMatrix(c(1,2,3), rows = c(1,1,2), cols = c(1,2,2))
   expect_true(is.null(dimnames(A)))
 
-  dms <- list(treated = c("A", "B"), control = c("x", "y"))
+  dms <- list(treatment = c("A", "B"), control = c("x", "y"))
   dimnames(A) <- dms
   expect_equal(dimnames(A), dms)
 
@@ -362,7 +362,7 @@ test_that("t(ransform) function", {
   # we call t(m), everything is labeled properly
   m <- matrix(c(1,Inf, 2, 3), nrow = 2, ncol = 2,
               dimnames = list(control = c("A", "B"),
-                              treated = c("C", "D")))
+                              treatment = c("C", "D")))
   A <- as.InfinitySparseMatrix(m)
 
   expect_equal(as.matrix(t(A)), t(m))
@@ -416,7 +416,7 @@ test_that("Get subproblem size of each block", {
 
   m <- matrix(c(1,Inf, 2, 3), nrow = 2, ncol = 2,
               dimnames = list(control = c("A", "B"),
-                  treated = c("C", "D")))
+                  treatment = c("C", "D")))
   a <- as.InfinitySparseMatrix(m)
 
   # subdim on a matrix or non-blocked ISM is equivalent to calling dim

--- a/tests/testthat/test.caliper.R
+++ b/tests/testthat/test.caliper.R
@@ -6,7 +6,7 @@ context("Caliper")
 
 test_that("Caliper return values", {
   m <- matrix(c(1,Inf, 2, 3), nrow = 2, ncol = 2,
-              dimnames = list(treated = c("A", "B"),
+              dimnames = list(treatment = c("A", "B"),
                               control = c("C", "D")))
   A <- as.InfinitySparseMatrix(m)
 
@@ -25,7 +25,7 @@ test_that("Caliper return values", {
 
 test_that("Caliper exclusion", {
   m <- matrix(c(3,Inf, 1, 3), nrow = 2, ncol = 2,
-              dimnames = list(treated = c("A", "B"),
+              dimnames = list(treatment = c("A", "B"),
                               control = c("C", "D")))
   A <- as.InfinitySparseMatrix(m)
 
@@ -34,7 +34,7 @@ test_that("Caliper exclusion", {
 
 
   m2 <- matrix(c(Inf,Inf, 0, 0), nrow = 2, ncol = 2,
-              dimnames = list(treated = c("A", "B"),
+              dimnames = list(treatment = c("A", "B"),
                               control = c("C", "D")))
 
   expect_equal(as.matrix(result), m2)

--- a/tests/testthat/test.distUnion.R
+++ b/tests/testthat/test.distUnion.R
@@ -11,7 +11,7 @@ test_that("distUnion Basics", {
   mbc <- matrix(7:8, nrow = 2, ncol = 1, dimnames = list(c("B", "C"), c("W")))
   expected <- matrix(c(Inf, 7, 8, 5, Inf, 6, 1, 2, Inf, 3, 4, Inf),
                      nrow = 3, ncol = 4,
-                     dimnames = list(treated = c("A", "B", "C"), control = c("W", "X", "Y", "Z")))
+                     dimnames = list(treatment = c("A", "B", "C"), control = c("W", "X", "Y", "Z")))
 
   iab <- optmatch:::as.InfinitySparseMatrix(mab)
   iac <- optmatch:::as.InfinitySparseMatrix(mac)

--- a/tests/testthat/test.exactMatch.R
+++ b/tests/testthat/test.exactMatch.R
@@ -218,7 +218,7 @@ test_that("antiExactMatch", {
 
   ex <- matrix(c(Inf, 0, 0, 0, Inf, 0, 0, 0, Inf), nrow = 3, ncol = 3,
                dimnames =list(
-                   treated = c("X2", "X4", "X6"),
+                   treatment = c("X2", "X4", "X6"),
                    control = c("X1", "X3", "X5")))
 
   res <- antiExactMatch(x, z)


### PR DESCRIPTION
I replaced 'treated' with 'treatement' anywhere I found it in [R/InfinitySparseMatrix.R](https://github.com/markmfredrickson/optmatch/tree/ism-treated-treatment/R/InfinitySparseMatrix.R)

Then I ran devtools::check() and used the output to replace 'treated' with 'treatment` in any testthat test that failed or complained.

I did this in the branch [ism-treated-treatment](https://github.com/markmfredrickson/optmatch/tree/ism-treated-treatment)

See [Issue 249](https://github.com/markmfredrickson/optmatch/issues/249)